### PR TITLE
Add App Store and Microsoft Store badges to Klever project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ _temp/
 .jekyll-cache/
 .direnv/
 .DS_Store
+bin/

--- a/_projects/2024-06-01-klever.md
+++ b/_projects/2024-06-01-klever.md
@@ -23,6 +23,19 @@ Klever is a Figma plugin that leverages AppAgent's cutting-edge AI technology to
 %}
 {::options parse_block_html="true" /}
 
+<div style="text-align: center; margin: 30px 0;">
+  <div style="display: inline-flex; gap: 20px; flex-wrap: wrap; justify-content: center; align-items: center;">
+    <div class="store-badge"
+         data-name="Klever Instance UT"
+         data-app-store-url="https://apps.apple.com/us/app/klever-instance-ut/id6754501208"
+         data-target="_blank"></div>
+    <ms-store-badge productid="xp8brb9spkfrsw" theme="auto"></ms-store-badge>
+  </div>
+</div>
+
+<script async src="https://cdn.jsdelivr.net/npm/store-badge@1/build/bundle.js"></script>
+<script type="module" src="https://get.microsoft.com/badge/ms-store-badge.bundled.js"></script>
+
 This project was born out of a desire to address the evolving challenges faced by designers in an AI-driven world. In the following sections, we'll explore the inspiration behind Klever, the journey of its development, and the impactful results it has achieved. Join us as we delve into the story of how Klever came to be and the innovative solutions it offers.
 
 


### PR DESCRIPTION
Added download badges for both Apple App Store and Microsoft Store below the hero image in the Klever project documentation. The badges are centered and displayed side-by-side for better visibility.